### PR TITLE
Add .nuspec file for choco-crewlink Chocolatey package.

### DIFF
--- a/crewlink/crewlink.nuspec
+++ b/crewlink/crewlink.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>crewlink</id>
+    <!-- version should MATCH as closely as possible with the underlying software -->
+    <version>1.2.1</version>
+    <packageSourceUrl>Where is this Chocolatey package located (think GitHub)? packageSourceUrl is highly recommended for the community feed</packageSourceUrl>
+    <owners>mcdonagj</owners>
+    <title>crewlink (Install)</title>
+    <authors>ottomated</authors>
+    <projectUrl>https://github.com/ottomated/CrewLink</projectUrl>
+    <iconUrl>https://github.com/ottomated/CrewLink/raw/master/logo.png</iconUrl>
+    <projectSourceUrl>Software Source Location - is the software FOSS somewhere? Link to it with this</projectSourceUrl>
+    <tags>crewlink amongus</tags>
+    <summary>Free, open, Among Us proximity voice chat.</summary>
+    <description>__REPLACE__MarkDown_Okay </description>
+    <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
This change adds a `.nuspec` for the `choco-crewlink` package.

This file defines package information, such as version, title, owner, source URL, and package contents.

Future updates to the package will have revisions reflected in this file following semantic versioning.