### PR TITLE
Add chocolateybeforemodify.ps1 to choco-crewlink Chocolatey package.

### DIFF
--- a/crewlink/tools/chocolateybeforemodify.ps1
+++ b/crewlink/tools/chocolateybeforemodify.ps1
@@ -1,0 +1,9 @@
+﻿# This runs in 0.9.10+ before upgrade and uninstall.
+# Use this file to do things like stop services prior to upgrade or uninstall.
+# NOTE: It is an anti-pattern to call chocolateyUninstall.ps1 from here. If you
+#  need to uninstall an MSI prior to upgrade, put the functionality in this
+#  file without calling the uninstall script. Make it idempotent in the
+#  uninstall script so that it doesn't fail when it is already uninstalled.
+# NOTE: For upgrades - like the uninstall script, this script always runs from 
+#  the currently installed version, not from the new upgraded package version.
+


### PR DESCRIPTION
This change adds the `chocolateybeforemodify.ps1` script to the `choco-crewlink` package.

`chocolateybeforemodify.ps1` defines steps to be completed during the package before installation.