### PR TITLE
Add chocolateyinstall.ps1 to choco-crewlink Chocolatey package.

### DIFF
--- a/crewlink/tools/chocolateyinstall.ps1
+++ b/crewlink/tools/chocolateyinstall.ps1
@@ -1,0 +1,20 @@
+﻿$ErrorActionPreference = 'Stop';
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url        = 'https://github.com/ottomated/CrewLink/releases/download/v1.2.1/CrewLink-Setup-1.2.1.exe'
+
+$packageArgs = @{
+  packageName   = $env:ChocolateyPackageName
+  unzipLocation = $toolsDir
+  fileType      = 'exe'
+  url           = $url
+  url64bit      = $url64
+  softwareName  = 'CrewLink 1.2.1'
+  checksum      = 'f965348ac20fbecb79950a3f30737b05'
+  checksumType  = 'md5'
+  checksum64    = '0c0ff091dac843c5b8656cb9dbae1800a23380f878e8e60b032c074148dff36e'
+  checksumType64= 'sha256'
+  silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
+  validExitCodes= @(0, 3010, 1641)
+}
+
+Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
The change adds the `chocolateyinstall.ps1` script for the `choco-crewlink` Chocolatey package.

This script enables steps for installation of Crewlink via Chocolatey.