### PR TITLE
Add chocolateyuninstall.ps1 to choco-crewlink package.

### DIFF
--- a/crewlink/tools/chocolateyuninstall.ps1
+++ b/crewlink/tools/chocolateyuninstall.ps1
@@ -1,0 +1,18 @@
+﻿# IMPORTANT: Before releasing this package, copy/paste the next 2 lines into PowerShell to remove all comments from this file:
+#   $f='c:\path\to\thisFile.ps1'
+#   gc $f | ? {$_ -notmatch "^\s*#"} | % {$_ -replace '(^.*?)\s*?[^``]#.*','$1'} | Out-File $f+".~" -en utf8; mv -fo $f+".~" $f
+
+$ErrorActionPreference = 'Stop';
+$packageArgs = @{
+  packageName   = $env:ChocolateyPackageName
+  softwareName  = 'CrewLink 1.2.1'
+  fileType      = 'exe'
+  #silentArgs    = "/qn /norestart"
+  validExitCodes= @(0, 3010, 1605, 1614, 1641)
+}
+
+$uninstalled = $false
+
+#[array]$key = Get-UninstallRegistryKey -SoftwareName $packageArgs['softwareName']
+
+Uninstall-ChocolateyPackage @packageArgs


### PR DESCRIPTION
This change adds the `chocolateyuninstall.ps1` script to the `choco-crewlink` package.

This script defines uninstallation steps for the `choco-crewlink` package.